### PR TITLE
fix: make typed rule type checking resilient to empty GOROOT

### DIFF
--- a/lint/package.go
+++ b/lint/package.go
@@ -112,7 +112,7 @@ func (p *Package) TypeCheck() error {
 	config := &types.Config{
 		// By setting a no-op error reporter, the type checker does as much work as possible.
 		Error:    func(error) {},
-		Importer: importer.Default(),
+		Importer: importer.ForCompiler(p.fset, "source", nil),
 	}
 	info := &types.Info{
 		Types:  map[ast.Expr]types.TypeAndValue{},

--- a/lint/package.go
+++ b/lint/package.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"errors"
 	"go/ast"
+	"go/build"
 	"go/importer"
 	"go/token"
 	"go/types"
@@ -81,6 +82,9 @@ func ensureSourceImporterGOROOT(runtimeGOROOT string) {
 
 	if goroot != "" {
 		_ = os.Setenv("GOROOT", goroot)
+		if build.Default.GOROOT == "" {
+			build.Default.GOROOT = goroot
+		}
 	}
 }
 

--- a/lint/package.go
+++ b/lint/package.go
@@ -6,6 +6,10 @@ import (
 	"go/importer"
 	"go/token"
 	"go/types"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
 	"sync"
 
 	goversion "github.com/hashicorp/go-version"
@@ -45,6 +49,40 @@ var (
 	// Go125 is a constant representing the Go version 1.25.
 	Go125 = goversion.Must(goversion.NewVersion("1.25"))
 )
+
+var (
+	sourceImporterGOROOTOnce = sync.Once{}
+	sourceImporterGOROOT     string
+	sourceImporterGOROOTCmd  = func() (string, error) {
+		out, err := exec.Command("go", "env", "GOROOT").Output()
+		if err != nil {
+			return "", err
+		}
+		return strings.TrimSpace(string(out)), nil
+	}
+)
+
+func ensureSourceImporterGOROOT(runtimeGOROOT string) {
+	if os.Getenv("GOROOT") != "" {
+		return
+	}
+
+	goroot := runtimeGOROOT
+	if goroot == "" {
+		sourceImporterGOROOTOnce.Do(func() {
+			resolved, err := sourceImporterGOROOTCmd()
+			if err != nil {
+				return
+			}
+			sourceImporterGOROOT = strings.TrimSpace(resolved)
+		})
+		goroot = sourceImporterGOROOT
+	}
+
+	if goroot != "" {
+		_ = os.Setenv("GOROOT", goroot)
+	}
+}
 
 // Files return package's files.
 func (p *Package) Files() map[string]*File {
@@ -108,6 +146,8 @@ func (p *Package) TypeCheck() error {
 	if alreadyTypeChecked {
 		return nil
 	}
+
+	ensureSourceImporterGOROOT(runtime.GOROOT())
 
 	config := &types.Config{
 		// By setting a no-op error reporter, the type checker does as much work as possible.

--- a/lint/package_typecheck_test.go
+++ b/lint/package_typecheck_test.go
@@ -4,6 +4,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"os"
+	"sync"
 	"testing"
 )
 
@@ -51,5 +53,29 @@ func f() { fmt.Println("ok") }
 	}
 	if got := pkg.TypeOf(printCall.Fun); got == nil {
 		t.Fatal("expected type info for fmt.Println call")
+	}
+}
+
+func TestEnsureSourceImporterGOROOTUsesGoEnvFallback(t *testing.T) {
+	t.Setenv("GOROOT", "")
+
+	prevCmd := sourceImporterGOROOTCmd
+	prevResolved := sourceImporterGOROOT
+	t.Cleanup(func() {
+		sourceImporterGOROOTCmd = prevCmd
+		sourceImporterGOROOT = prevResolved
+		sourceImporterGOROOTOnce = sync.Once{}
+	})
+
+	sourceImporterGOROOTOnce = sync.Once{}
+	sourceImporterGOROOT = ""
+	sourceImporterGOROOTCmd = func() (string, error) {
+		return "C:/go-fallback\n", nil
+	}
+
+	ensureSourceImporterGOROOT("")
+
+	if got := os.Getenv("GOROOT"); got != "C:/go-fallback" {
+		t.Fatalf("expected GOROOT to be set from go env fallback, got %q", got)
 	}
 }

--- a/lint/package_typecheck_test.go
+++ b/lint/package_typecheck_test.go
@@ -2,6 +2,7 @@ package lint
 
 import (
 	"go/ast"
+	"go/build"
 	"go/parser"
 	"go/token"
 	"os"
@@ -61,10 +62,12 @@ func TestEnsureSourceImporterGOROOTUsesGoEnvFallback(t *testing.T) {
 
 	prevCmd := sourceImporterGOROOTCmd
 	prevResolved := sourceImporterGOROOT
+	prevBuildGOROOT := build.Default.GOROOT
 	t.Cleanup(func() {
 		sourceImporterGOROOTCmd = prevCmd
 		sourceImporterGOROOT = prevResolved
 		sourceImporterGOROOTOnce = sync.Once{}
+		build.Default.GOROOT = prevBuildGOROOT
 	})
 
 	sourceImporterGOROOTOnce = sync.Once{}
@@ -72,10 +75,14 @@ func TestEnsureSourceImporterGOROOTUsesGoEnvFallback(t *testing.T) {
 	sourceImporterGOROOTCmd = func() (string, error) {
 		return "C:/go-fallback\n", nil
 	}
+	build.Default.GOROOT = ""
 
 	ensureSourceImporterGOROOT("")
 
 	if got := os.Getenv("GOROOT"); got != "C:/go-fallback" {
 		t.Fatalf("expected GOROOT to be set from go env fallback, got %q", got)
+	}
+	if got := build.Default.GOROOT; got != "C:/go-fallback" {
+		t.Fatalf("expected build.Default.GOROOT to be set from go env fallback, got %q", got)
 	}
 }

--- a/lint/package_typecheck_test.go
+++ b/lint/package_typecheck_test.go
@@ -1,0 +1,55 @@
+package lint
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+)
+
+func TestPackageTypeCheckWithEmptyGOROOT(t *testing.T) {
+	t.Setenv("GOROOT", "")
+
+	fset := token.NewFileSet()
+	src := `package p
+import "fmt"
+func f() { fmt.Println("ok") }
+`
+
+	parsed, err := parser.ParseFile(fset, "p.go", src, parser.AllErrors)
+	if err != nil {
+		t.Fatalf("parse failed: %v", err)
+	}
+
+	pkg := &Package{
+		fset: fset,
+		files: map[string]*File{
+			"p.go": {
+				Name: "p.go",
+				AST:  parsed,
+				Pkg:  nil,
+			},
+		},
+	}
+	pkg.files["p.go"].Pkg = pkg
+
+	if err := pkg.TypeCheck(); err != nil {
+		t.Fatalf("type check failed with empty GOROOT: %v", err)
+	}
+
+	var printCall *ast.CallExpr
+	ast.Inspect(parsed, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if ok {
+			printCall = call
+			return false
+		}
+		return true
+	})
+	if printCall == nil {
+		t.Fatal("expected to find fmt.Println call")
+	}
+	if got := pkg.TypeOf(printCall.Fun); got == nil {
+		t.Fatal("expected type info for fmt.Println call")
+	}
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests for Go type checking to verify runtime environment handling and type information resolution in various scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->